### PR TITLE
Replace `label.size` unit

### DIFF
--- a/vignettes/Suggested_plantTracker_Workflow.Rmd
+++ b/vignettes/Suggested_plantTracker_Workflow.Rmd
@@ -829,7 +829,7 @@ ggplot(datComp) +
   geom_sf(data = countMethod, aes(), alpha = 0, lwd = 1.5) +
   geom_sf_label(data = countMethod, label = c(1,2,3,4,5), nudge_x = .035, 
                 label.padding = unit(.15, "lines"),
-                label.size = unit(.05,"mm")) +
+                label.size = 0.1) +
   xlim(c(0,.5)) +
   ylim(c(.2,.7)) +
   xlab("quadrat horizontal edge (m)") +


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
We found that a `label.size` parameter was given as a unit, whereas it should be a plain numeric value.
This PR replaces the unit.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun